### PR TITLE
fall back to default font when arial.ttf not found

### DIFF
--- a/game_gia.py
+++ b/game_gia.py
@@ -359,7 +359,12 @@ def make_letter_image(letter, side, angle):
         kivy.core.image.CoreImage: The resulting CoreImage
     """
     # Define text font
-    fnt = ImageFont.truetype('arial.ttf', 85)
+    font_size = 85
+    try:
+        fnt = ImageFont.truetype('arial.ttf', font_size)
+    except OSError:
+        fnt = ImageFont.load_default(font_size)
+
     # Create a new PIL image
     image = Image.new(mode="RGB", size=(150, 150), color="white")
     # Draw the letter on the image


### PR DESCRIPTION
Hi, thanks for providing this mock GIA test!
I don't have the arial font installed on my system so the spacial test fails to start.
The patch falls back to use the default font found in the system if arial is not present.